### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ feature_branch: &feature_branch
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.4
+  hmpps: ministryofjustice/hmpps@7
   slack: circleci/slack@4.12.5
 
 parameters:
@@ -53,7 +53,8 @@ jobs:
             export BUILD_NUMBER=${DATE}.${CIRCLE_BUILD_NUM}
             export GIT_REF="$CIRCLE_SHA1"
             npm run record-build-info
-      - run: # Run linter after build because the integration test code depend on compiled typescript...
+      - run:
+          # Run linter after build because the integration test code depend on compiled typescript...
           name: Linter check
           command: npm run lint
       - persist_to_workspace:
@@ -189,7 +190,7 @@ workflows:
           <<: *main_branch
           type: approval
           requires:
-           - deploy_dev
+            - deploy_dev
       - hmpps/deploy_env:
           name: deploy_preprod
           env: "preprod"

--- a/helm_deploy/hmpps-it-incident-hub/Chart.yaml
+++ b/helm_deploy/hmpps-it-incident-hub/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-it-incident-hub
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.7.1
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3

--- a/helm_deploy/hmpps-it-incident-hub/values.yaml
+++ b/helm_deploy/hmpps-it-incident-hub/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-it-incident-hub
 
@@ -6,12 +5,12 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-it-incident-hub
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 3000
 
   ingress:
     enabled: true
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-it-incident-hub-cert
 
   livenessProbe:
@@ -62,35 +61,12 @@ generic-service:
       REDIS_AUTH_TOKEN: "auth_token"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    ark-dom1-psn1: 51.247.4.0/24
-    ark-dom1-psn2: 51.247.3.0/24
-    ark-dom1-ttp1: "195.59.75.0/24"
-    ark-dom1-farnborough: "194.33.192.0/24"
-    ark-dom1-corsham: "194.33.196.0/24"
-    ark-nps-hmcts-ttp1: 195.59.75.0/24
-    ark-nps-hmcts-ttp2: 194.33.192.0/25
-    ark-nps-hmcts-ttp3: 194.33.193.0/25
-    ark-nps-hmcts-ttp4: 194.33.196.0/25
-    ark-nps-hmcts-ttp5: 194.33.197.0/25
-    dxc_webproxy1: 195.92.38.20/32
-    dxc_webproxy2: 195.92.38.21/32
-    dxc_webproxy3: 195.92.38.22/32
-    dxc_webproxy4: 195.92.38.23/32
-    moj-official-tgw-preprod: 51.149.251.0/24
-    moj-official-tgw-prod: 51.149.250.0/24
-    moj-official-ark-c-expo-e: 51.149.249.0/29
-    moj-official-ark-c-vodafone: 194.33.248.0/29
-    moj-official-ark-f-vodafone: 194.33.249.0/29
-    moj-official-ark-f-expo-e: 51.149.249.32/29
+    ark-dom1-farnborough: 194.33.192.0/24
+    ark-dom1-corsham: 194.33.196.0/24
     ext-digital-accessibility-centre: 194.75.245.154/32
+    groups:
+      - internal
+      - prisons
 
 generic-prometheus-alerts:
   targetApplication: hmpps-it-incident-hub


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-it-incident-hub/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal,prisons`
- The size of the allowlist defined in this file will change: `28 => 3 (25 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- mojo-azure-landing-zone-public-egress-1
  

- mojo-azure-landing-zone-public-egress-2
  

- mojo-azure-landing-zone-public-egress-3
  

- mojo-azure-landing-zone-public-egress-4
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  

- ark-dom1-psn1
  

- ark-dom1-psn2
  

- dxc_webproxy1
  

- dxc_webproxy2
  

- dxc_webproxy3
  

- dxc_webprox23
  
